### PR TITLE
Add sdk version to global.json

### DIFF
--- a/1_Invoice_Api/Finance/global.json
+++ b/1_Invoice_Api/Finance/global.json
@@ -1,3 +1,6 @@
 {
-	"projects": [ "src", "test"]
+	"projects": [ "src", "test"],
+	"sdk": {
+        "version": "1.0.0-preview2-003131"
+	}
 }

--- a/2_Invoice_Api/Finance/global.json
+++ b/2_Invoice_Api/Finance/global.json
@@ -1,3 +1,6 @@
 {
-	"projects": [ "src", "test"]
+	"projects": [ "src", "test"],
+	"sdk": {
+        "version": "1.0.0-preview2-003131"
+	}
 }


### PR DESCRIPTION
To be able to build the solutions on machines with newer SDK's installed
the global.json must include the version of the sdk used to build the
solution.